### PR TITLE
Allow jsonschema<2.0 too.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jsonschema>=0.7,<1
+jsonschema>=0.7,<2
 jsonpatch>=0.10,<=0.12


### PR DESCRIPTION
Tests still pass and we need it for openSUSE.
