### PR TITLE
Adding support for linking models that have required attributes

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -38,6 +38,24 @@ complex_fixture = {
     },
 }
 
+parent_fixture = {
+    'name': 'Parent',
+    'properties': {
+        'name': {'type': 'string'},
+        'children': {'type': 'array', 'items': [{'type': 'object'}]}
+    },
+    'required': ['name', 'children']
+}
+
+child_fixture = {
+    'name': 'Child',
+    'properties': {
+        'age': {'type':'integer'},
+        'mother': {'type': 'object'}
+    },
+    'required': ['age', 'mother']
+}
+
 
 class TestCore(unittest.TestCase):
     def test_create_invalid_object(self):
@@ -202,3 +220,17 @@ class TestCore(unittest.TestCase):
             sweden.patch,
             '[{"path": "/name", "value": "Finland", "op": "replace"}, '
             '{"path": "/population", "value": 5387000, "op": "replace"}]')
+
+    def test_recursive_models(self):
+        Parent = warlock.model_factory(parent_fixture)
+        Child = warlock.model_factory(child_fixture)
+
+        mom = Parent(name='Abby', children=[])
+
+        teenager = Child(age=15, mother=mom)
+        toddler = Child(age=3, mother=mom)
+
+        mom.children = [teenager, toddler]
+
+        self.assertEqual(mom.children[0].age, 15)
+        self.assertEqual(mom.children[1].age, 3)

--- a/warlock/model.py
+++ b/warlock/model.py
@@ -91,6 +91,12 @@ class Model(dict):
     def copy(self):
         return copy.deepcopy(dict(self))
 
+    def __copy__(self):
+        return self.copy()
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(dict(self), memo)
+
     def update(self, other):
         mutation = dict(self.items())
         mutation.update(other)


### PR DESCRIPTION
I added a test case that shows what I'm trying to fix, but in brief:

You can't reference one model/dict from another model/dict, if the first has 'required' attributes. This seems to be due to copy.deepcopy's implementation of `_deepcopy_dict` - it uses `__setattr__` to copy individual keys/values over, which breaks because Model validates itself on every `__setattr__` call.

The way to resolve this is by using hooks that deepcopy offers called `__deepcopy__` and `__copy__` (https://docs.python.org/2/library/copy.html#copy.deepcopy)