### PR TITLE
Make 'name' optional

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -41,6 +41,15 @@ complex_fixture = {
 }
 
 
+nameless_fixture = {
+    'properties': {
+        'name': {'type': 'string'},
+        'population': {'type': 'integer'},
+    },
+    'additionalProperties': False,
+}
+
+
 class TestCore(unittest.TestCase):
     def test_create_invalid_object(self):
         Country = warlock.model_factory(fixture)
@@ -96,6 +105,19 @@ class TestCore(unittest.TestCase):
         exc = warlock.InvalidOperation
         self.assertRaises(exc, sweden.update, {'population': 'N/A'})
         self.assertRaises(exc, sweden.update, {'overloard': 'Bears'})
+    
+    def test_naming(self):
+        Country = warlock.model_factory(fixture)
+        self.assertEqual(Country.__name__, 'Country')
+        
+        Country2 = warlock.model_factory(fixture, name='Country2')
+        self.assertEqual(Country2.__name__, 'Country2')
+        
+        nameless = warlock.model_factory(nameless_fixture)
+        self.assertEqual(nameless.__name__, 'Model')
+        
+        nameless2 = warlock.model_factory(nameless_fixture, name='Country3')
+        self.assertEqual(nameless2.__name__, 'Country3')
 
     def test_deepcopy(self):
         """Make sure we aren't leaking references."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,pep8
+envlist = py26,py27,py33,py34,pep8
 
 [testenv]
 deps=pytest

--- a/warlock/core.py
+++ b/warlock/core.py
@@ -19,10 +19,11 @@ import copy
 from . import model
 
 
-def model_factory(schema, base_class=model.Model):
+def model_factory(schema, base_class=model.Model, name=None):
     """Generate a model class based on the provided JSON Schema
 
     :param schema: dict representing valid JSON schema
+    :param name: A name to give the class, if `name` is not in `schema`
     """
     schema = copy.deepcopy(schema)
 
@@ -31,5 +32,8 @@ def model_factory(schema, base_class=model.Model):
             self.__dict__['schema'] = schema
             base_class.__init__(self, *args, **kwargs)
 
-    Model.__name__ = str(schema['name'])
+    if name is not None:
+        Model.__name__ = name
+    elif 'name' in schema:
+        Model.__name__ = str(schema['name'])
     return Model


### PR DESCRIPTION
As an answer to #16, this commit makes the `name` attribute optional, and also allows it as input to the `model_factory` function for those who want to control the name but can't control the id.

I didn't try and use the id attribute, as that isn't necessarily there and may not be a python identifier. 