### PR TITLE
Better error message on __setitem__ failure

### DIFF
--- a/warlock/model.py
+++ b/warlock/model.py
@@ -45,7 +45,7 @@ class Model(dict):
         try:
             self.validate(mutation)
         except exceptions.ValidationError as exc:
-            msg = ("Unable to set '%s' to '%s'. Reason: %s"
+            msg = ("Unable to set '%s' to %r. Reason: %s"
                    % (key, value, str(exc)))
             raise exceptions.InvalidOperation(msg)
 


### PR DESCRIPTION
I'm not a Python expert, but I think that using `repr` instead of a quoted `str` is better in most cases.