### PR TITLE
Undo changes to the `warlock.model_factory` API

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -262,8 +262,8 @@ class TestCore(unittest.TestCase):
 
         country_schema = json.load(country_schema_file)
         person_schema = json.load(person_schema_file)
-        Country = warlock.model_factory(country_schema, resolver)
-        Person = warlock.model_factory(person_schema, resolver)
+        Country = warlock.model_factory(country_schema, resolver=resolver)
+        Person = warlock.model_factory(person_schema, resolver=resolver)
 
         england = Country(
             name="England",

--- a/warlock/core.py
+++ b/warlock/core.py
@@ -19,7 +19,7 @@ import copy
 from . import model
 
 
-def model_factory(schema, resolver=None, base_class=model.Model, name=None):
+def model_factory(schema, base_class=model.Model, name=None, resolver=None):
     """Generate a model class based on the provided JSON Schema
 
     :param schema: dict representing valid JSON schema


### PR DESCRIPTION
The changes introduced by commit 64a771d151a5defb9bca82042f ("Allow
resolver to be set on the Model") added a new keyword argument to the
`warlock.model_factory` function. Due to the way Python handles
positional arguments, the change alters the way that existing code is
interpreted.

Before the change,

    warlock.model_factory(schema_arg, snd_pos_arg)

would execute with

    kwargs == {
        'base_class': snd_pos_arg,
        'name': None,
    }

but after the change it's interpreted as

    kwargs == {
        'resolver': snd_pos_arg,
        'base_class'=model.Model,
        'name': None,
    }

This commit re-arranges the arguments to restore the previous behaviour
in an effort to not break existing code.