### PR TITLE
use io module for handling encoding while opening file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,18 +13,19 @@
 # limitations under the License.
 
 import setuptools
+import io
 import os
 
 
 def parse_requirements():
-    fap = open("requirements.txt", "r", encoding="utf-8")
+    fap = io.open("requirements.txt", "r", encoding="utf-8")
     raw_req = fap.read()
     fap.close()
     return raw_req.split("\n")
 
 
 def read(fname):
-    with open(
+    with io.open(
         os.path.join(os.path.dirname(__file__), fname), "r", encoding="utf-8"
     ) as fp:
         return fp.read()


### PR DESCRIPTION
Currently in release 1.3.2 is failing while doing python setup.py
install with TypeError: 'encoding' is an invalid keyword argument
for this function while reading warlock/setup.py", line 28, in read
os.path.join(os.path.dirname(__file__), fname), "r", encoding="utf-8"

By using io module while reading the file fixes the issue.

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>