### PR TITLE
maintain the validator instance to speedup schema validation process

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -285,3 +285,29 @@ class TestCore(unittest.TestCase):
 
         self.assertEqual(mom.children[0].age, 15)
         self.assertEqual(mom.children[1].age, 3)
+
+    def test_benchmark(self):
+        from jsonschema import RefResolver
+        import time
+
+        t0 = time.time()
+
+        dirname = os.path.dirname(__file__)
+        schemas_path = "file://" + os.path.join(dirname, "schemas/")
+        resolver = RefResolver(schemas_path, None)
+
+        country_schema_file = open(os.path.join(dirname, "schemas/") + "country.json")
+
+        country_schema = json.load(country_schema_file)
+        Country = warlock.model_factory(country_schema, resolver=resolver)
+        obj = Country()
+
+        qs = [dict({'name': str(i), 'overlord': {'title': str(i)}}) for i in range(100)]
+
+        for build in qs:
+            # obj.update(build)
+            obj['name'] = build['name']
+            obj['overlord'] = build['overlord']
+
+        t1 = time.time()
+        print(f'time: {(t1-t0) * 1000}')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -285,29 +285,3 @@ class TestCore(unittest.TestCase):
 
         self.assertEqual(mom.children[0].age, 15)
         self.assertEqual(mom.children[1].age, 3)
-
-    def test_benchmark(self):
-        from jsonschema import RefResolver
-        import time
-
-        t0 = time.time()
-
-        dirname = os.path.dirname(__file__)
-        schemas_path = "file://" + os.path.join(dirname, "schemas/")
-        resolver = RefResolver(schemas_path, None)
-
-        country_schema_file = open(os.path.join(dirname, "schemas/") + "country.json")
-
-        country_schema = json.load(country_schema_file)
-        Country = warlock.model_factory(country_schema, resolver=resolver)
-        obj = Country()
-
-        qs = [dict({'name': str(i), 'overlord': {'title': str(i)}}) for i in range(100)]
-
-        for build in qs:
-            # obj.update(build)
-            obj['name'] = build['name']
-            obj['overlord'] = build['overlord']
-
-        t1 = time.time()
-        print(f'time: {(t1-t0) * 1000}')

--- a/warlock/core.py
+++ b/warlock/core.py
@@ -17,6 +17,7 @@
 import copy
 
 from . import model
+from jsonschema.validators import validator_for
 
 
 def model_factory(schema, base_class=model.Model, name=None, resolver=None):
@@ -32,6 +33,13 @@ def model_factory(schema, base_class=model.Model, name=None, resolver=None):
         def __init__(self, *args, **kwargs):
             self.__dict__["schema"] = schema
             self.__dict__["resolver"] = resolver
+
+            cls = validator_for(self.schema)
+            if resolver is not None:
+                self.__dict__["validator_instance"] = cls(schema, resolver=resolver)
+            else:
+                self.__dict__["validator_instance"] = cls(schema)
+
             base_class.__init__(self, *args, **kwargs)
 
     if resolver is not None:

--- a/warlock/model.py
+++ b/warlock/model.py
@@ -127,9 +127,12 @@ class Model(dict):
     def validate(self, obj):
         """Apply a JSON schema to an object"""
         try:
-            if self.resolver is not None:
-                jsonschema.validate(obj, self.schema, resolver=self.resolver)
-            else:
-                jsonschema.validate(obj, self.schema)
+            # if self.resolver is not None:
+            #     jsonschema.validate(obj, self.schema, resolver=self.resolver)
+            # else:
+            #     jsonschema.validate(obj, self.schema)
+
+            self.validator_instance.validate(obj)
+
         except jsonschema.ValidationError as exc:
             raise exceptions.ValidationError(str(exc))

--- a/warlock/model.py
+++ b/warlock/model.py
@@ -127,11 +127,6 @@ class Model(dict):
     def validate(self, obj):
         """Apply a JSON schema to an object"""
         try:
-            # if self.resolver is not None:
-            #     jsonschema.validate(obj, self.schema, resolver=self.resolver)
-            # else:
-            #     jsonschema.validate(obj, self.schema)
-
             self.validator_instance.validate(obj)
 
         except jsonschema.ValidationError as exc:


### PR DESCRIPTION
Given a schema (and possibly a resolver), jsonschema creates a validator first by compiling the schemas and uses it to validate data. If inside the class object, the validator instance is maintained, the validation overhead can be reduced, instead of creating a new validator every time. 

In this PR, `test_benchmark` in `test_core.py` is to measure the timing difference for the PR review.  It can be removed once we finish reviewing and discussing.