### PR TITLE
tox: Install a local instance of poetry

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 envlist = py35,py36,py37,py38
 
 [testenv]
-whitelist_externals = poetry
 skip_install = true
+deps =
+  poetry
 commands =
   poetry install -v
   poetry run pytest


### PR DESCRIPTION
Install poetry via tox's deps key rather than relying on it being
present as an external executable.  This makes it possible to run tests
via tox on systems that lack poetry.