### PR TITLE
Use poetry-core as the build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ known_third_party = ["jsonpatch","jsonschema"]
 known_first_party=["warlock"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Use poetry-core rather than poetry as the build backend.  This
is the recommended upstream solution, as it produces the same end result
while not requiring the tools to install the complete set of poetry
dependencies while building the wheel, effectively making the builds
much faster.

See "Why is this required?" at https://pypi.org/project/poetry-core/